### PR TITLE
perf: add CMakeCache.txt check to avoid reconfiguring

### DIFF
--- a/crates/pixi-build/src/bin/pixi-build-cmake/build_script.j2
+++ b/crates/pixi-build/src/bin/pixi-build-cmake/build_script.j2
@@ -1,28 +1,35 @@
 ninja --version
 cmake --version
 
+# Windows
 {% if build_platform == "windows" -%}
-cmake %CMAKE_ARGS% ^
-      -GNinja ^
-      -DCMAKE_BUILD_TYPE=Release ^
-      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-      -DBUILD_SHARED_LIBS=ON ^
-      -B %SRC_DIR%\..\build ^
-      -S "{{ source_dir }}"
-@if errorlevel 1 exit 1
+if not exist %SRC_DIR%\..\build\CMakeCache.txt (
+    cmake %CMAKE_ARGS% ^
+          -GNinja ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+          -DBUILD_SHARED_LIBS=ON ^
+          -B %SRC_DIR%\..\build ^
+          -S "{{ source_dir }}"
+    @if errorlevel 1 exit 1
+)
 cmake --build %SRC_DIR%\..\build --target install
 @if errorlevel 1 exit 1
+
+# Non-Windows
 {% else -%}
-cmake $CMAKE_ARGS \
-      -GNinja \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=$PREFIX \
-      -DBUILD_SHARED_LIBS=ON \
-      -B $SRC_DIR/../build \
-      -S "{{ source_dir }}"
+if [ ! -f "$SRC_DIR/../build/CMakeCache.txt" ]; then
+    cmake $CMAKE_ARGS \
+          -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=$PREFIX \
+          -DBUILD_SHARED_LIBS=ON \
+          -B $SRC_DIR/../build \
+          -S "{{ source_dir }}"
+fi
 cmake --build $SRC_DIR/../build --target install
 {% endif -%}
 
 {% if build_platform == "windows" -%}
-if errorlevel 1 exit 1
+@if errorlevel 1 exit 1
 {% endif %}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7be25462-0cc4-4697-adf4-a507473f3036)
Speeds up incremental cmake builds drastically when the changes are minimal 